### PR TITLE
Return request uri and request body in error objects

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,8 @@
-function apply(src, tar) {
+function apply(src, tar, uri, body) {
 	tar.statusMessage = src.statusText;
 	tar.statusCode = src.status;
+	tar.uri = uri;
+	tar.body = body;
 	tar.data = src.body;
 }
 
@@ -32,7 +34,7 @@ export function send(method, uri, opts) {
 		fetch(uri, opts).then((rr, reply) => {
 			clearTimeout(timer);
 
-			apply(rr, rr); //=> rr.headers
+			apply(rr, rr, uri, opts.body); //=> rr.headers
 			reply = rr.status >= 400 ? rej : res;
 
 			tmp = rr.headers.get('content-type');
@@ -45,7 +47,7 @@ export function send(method, uri, opts) {
 						reply(rr);
 					} catch (err) {
 						err.headers = rr.headers;
-						apply(rr, err);
+						apply(rr, err, uri, opts.body);
 						rej(err);
 					}
 				});

--- a/src/node.js
+++ b/src/node.js
@@ -2,12 +2,14 @@ import { request } from 'https';
 import { globalAgent } from 'http';
 import { parse, resolve } from 'url';
 
-function toError(rej, res, err) {
+function toError(rej, res, err, uri, body) {
 	err = err || new Error(res.statusMessage);
 	err.statusMessage = res.statusMessage;
 	err.statusCode = res.statusCode;
 	err.headers = res.headers;
 	err.data = res.data;
+	err.uri = uri;
+	err.body = body;
 	rej(err);
 }
 
@@ -37,12 +39,12 @@ export function send(method, uri, opts={}) {
 					try {
 						out = JSON.parse(out, opts.reviver);
 					} catch (err) {
-						return toError(rej, rr, err);
+						return toError(rej, rr, err, uri, opts.body);
 					}
 				}
 				rr.data = out;
 				if (rr.statusCode >= 400) {
-					toError(rej, rr);
+					toError(rej, rr, null, uri, opts.body);
 				} else {
 					res(rr);
 				}

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -1,7 +1,9 @@
-function apply(src, tar) {
+function apply(src, tar, uri, body) {
 	tar.headers = src.headers || {};
 	tar.statusMessage = src.statusText;
 	tar.statusCode = src.status;
+	tar.uri = src.uri;
+	tar.body = src.body;
 	tar.data = src.response;
 }
 
@@ -23,7 +25,7 @@ export function send(method, uri, opts) {
 
 		req.onload = function () {
 			arr = req.getAllResponseHeaders().trim().split(/[\r\n]+/);
-			apply(req, req); //=> req.headers
+			apply(req, req, uri.href || uri, str); //=> req.headers
 
 			while (tmp = arr.shift()) {
 				tmp = tmp.split(': ');
@@ -35,7 +37,7 @@ export function send(method, uri, opts) {
 				try {
 					req.data = JSON.parse(req.data, opts.reviver);
 				} catch (err) {
-					apply(req, err);
+					apply(req, err, uri.href || uri, str);
 					return rej(err);
 				}
 			}

--- a/test/node.js
+++ b/test/node.js
@@ -33,6 +33,8 @@ test('GET (404)', async () => {
 		assert.instance(err, Error, '~> returns a true Error instance');
 		assert.is(err.message, err.statusMessage, '~> the "message" and "statusMessage" are identical');
 		assert.is(err.message, 'Not Found', '~~> Not Found');
+		assert.is(err.statusCode, 404);
+		assert.is(err.uri, 'https://reqres.in/api/users/23');
 		isResponse(err, 404, {}); // +5
 	}
 });
@@ -113,6 +115,7 @@ test('POST (string body w/ object url)', async () => {
 	const uri = parse('https://reqres.in/api/login');
 	await httpie.post(uri, { body }).catch(err => {
 		assert.is(err.message, 'Bad Request');
+		assert.is(err.body, 'peter@klaven')
 		isResponse(err, 400, {
 			error: 'Missing email or username'
 		});


### PR DESCRIPTION
If you look at an http error in Sentry, you'll see a stack trace that isn't very helpful.  Due to the event loop, we can't see where the http call originated.  We can guess based on what's in the response headers and response data, or other things in Sentry.  But that seems pretty dumb.

This PR should make this error object also contain some request properties:

```diff
Error: Bad Request
    at toError (/root/node_modules/.pnpm/httpie@2.0.0-next.13/node_modules/httpie/node/index.mjs:6:15)
    at IncomingMessage.<anonymous> (/root/node_modules/.pnpm/httpie@2.0.0-next.13/node_modules/httpie/node/index.mjs:45:6)
    at IncomingMessage.emit (node:events:525:35)
    at IncomingMessage.emit (node:domain:489:12)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at processTicksAndRejections (node:internal/process/task_queues:82:21) {
+ uri: 'https://api.taxjar.com/v2/taxes',
+ body: '{ ... }',
  statusMessage: 'Bad Request',
  statusCode: 400,
  headers: {
    'content-type': 'application/json; charset=utf-8',
    'content-length': '80',
    connection: 'close',
    date: 'Fri, 27 Jan 2023 14:42:51 GMT',
    'x-amzn-requestid': '3dde45c8-2177-4ed3-9731-362c3ba43329',
    'x-amz-apigw-id': 'faBk5HRVoAMF8aQ=',
    'x-amzn-trace-id': 'Root=1-63d3e2eb-5834e99d7fcb85b82d83b504',
    'x-cache': 'Error from cloudfront',
    via: '1.1 2c7d387775f2e52dd268d2f49202b5d2.cloudfront.net (CloudFront)',
    'x-amz-cf-pop': 'EWR53-P1',
    'x-amz-cf-id': 'BUlSCpP0IhIJNtLZcOtWFdnxY1VqXhQiu_iQkdpVtbPufoPbSI_24Q=='
  },
  data: {
    status: 400,
    error: 'Bad Request',
    detail: 'No amount or line items provided'
  }
}
```

-----

Note: Before we publish to npm, we should change `package.json` links, `package.json` version, and the `readme.md`.